### PR TITLE
Bug fixes and support for legacy Ecobee Smart thermostats with remote sensors.

### DIFF
--- a/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
+++ b/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
@@ -59,10 +59,11 @@
  *	1.4.08-	Fix the inevitable typo that prevented clean initial install
  *	1.4.09- Trapped another exception (org.apache.http.conn.HttpHostConnectException)
  *	1.4.10- Fixed sendJson LOG error
+ *  1.4.10a- Added support for legacy Ecobee Smart thermostats with remote sensors.  Fixed bug with multi-thermostat enumeration of remote sensors.
  */  
 import groovy.json.JsonOutput
 
-def getVersionNum() { return "1.4.10" }
+def getVersionNum() { return "1.4.10a" }
 private def getVersionLabel() { return "Ecobee Suite Manager, version ${getVersionNum()}" }
 private def getHelperSmartApps() {
 	return [ 
@@ -875,20 +876,25 @@ Map getEcobeeSensors() {
 			if (it.type == "ecobee3_remote_sensor") {
             	LOG("Adding an ecobee3_remote_sensor: ${it}", 4, null, "trace")
 				def value = "${it?.name}"
-				def key = "ecobee_suite-sensor-"+ it?.id + "-" + it?.code
+				def key = "ecobee_suite-sensor-" + tid + "." + it?.id + "-" + it?.code
 				sensorMap["${key}"] = value
 			} else if ( (it.type == "thermostat") && (settings.showThermsAsSensor == true) ) {            	
 				LOG("Adding a Thermostat as a Sensor: ${it}", 4, null, "trace")
            	    def value = "${it?.name}"
-				def key = "ecobee_suite-sensor_tstat-"+ it?.id + "-" + it?.name
+				def key = "ecobee_suite-sensor_tstat-" + tid + "." + it?.id + "-" + it?.name
        	       	LOG("Adding a Thermostat as a Sensor: ${it}, key: ${key}  value: ${value}", 4, null, "trace")
 				sensorMap["${key}"] = value + " (Thermostat)"
        	   	} else if ( it.type == "control_sensor" && it.capability[0]?.type == "temperature") {
        	   		// We can add this one as it supports temperature
        	      	LOG("Adding a control_sensor: ${it}", 4, null, "trace")
 				def value = "${it?.name}"
-				def key = "ecobee_suite-control_sensor-"+ it?.id
-				sensorMap["${key}"] = value    
+				def key = "ecobee_suite-control_sensor-" + tid + "." + it?.id
+				sensorMap["${key}"] = value
+            } else if (it.type == "monitor_sensor" && it.capability[0]?.type == "temperature" && it?.name != "") {
+            	LOG("Adding a monitor_sensor: ${it}", 4, null, "trace")
+				def value = "${it?.name}"
+				def key = "ecobee_suite-monitor_sensor-" + tid + "." + it?.id
+				sensorMap["${key}"] = value
            	} else {
            		LOG("Did NOT add: ${it}. settings.showThermsAsSensor=${settings.showThermsAsSensor}", 4, null, "trace")
            	}
@@ -2296,16 +2302,19 @@ def updateSensorData() {
         	switch (it.type) {
             	case 'ecobee3_remote_sensor':
                 	// Ecobee3 remote temp/occupancy sensor
-                	sensorDNI = "ecobee_suite-sensor-" + it?.id + "-" + it?.code
+                	sensorDNI = "ecobee_suite-sensor-" + tid + "." + it?.id + "-" + it?.code
                     break;
                 case 'control_sensor':
                 	// SmartSI style control sensor (temp or humidity)
-                	sensorDNI = "ecobee_suite-control_sensor-" + it?.id
+                	sensorDNI = "ecobee_suite-control_sensor-" + tid + "." + it?.id
                     break;
                 case 'thermostat':
                 	// The thermostat itself
-                	sensorDNI = "ecobee_suite-sensor_tstat-"+ it?.id + "-" + it?.name
+                	sensorDNI = "ecobee_suite-sensor_tstat-" + tid + "." + it?.id + "-" + it?.name
                     break;
+                case 'monitor_sensor':
+                	// Smart style remote sensor (temp or humidity)
+                    sensorDNI = "ecobee_suite-monitor_sensor-" + tid + "." + it?.id
      		} 
 			if (debugLevelFour) LOG("updateSensorData() - Sensor ${it.name}, sensorDNI == ${sensorDNI}", 4)
             	              
@@ -2318,7 +2327,7 @@ def updateSensorData() {
 					if (cap.type == "temperature") {
                    		if (debugLevelFour) LOG("updateSensorData() - Sensor (DNI: ${sensorDNI}) temp is ${cap.value}", 4)
                        	if ( cap.value.isNumber() ) { // Handles the case when the sensor is offline, which would return "unknown"
-							temperature = cap.value as Double
+							temperature = cap.value as Double                           
 							temperature = (temperature / 10).toDouble()  //.round(precision) // wantMetric() ? (temperature / 10).toDouble().round(1) : (temperature / 10).toDouble().round(1)
                        	} else if (cap.value == 'unknown') {
                        		// TODO: Do something here to mark the sensor as offline?

--- a/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
+++ b/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
@@ -51,19 +51,20 @@
  *	1.4.00- Renamed devices and manager, removed watchdogDevices
  *	1.4.01- Fix sensor device naming bug
  *	1.4.02- Handle javax.net.ssl.SSLPeerUnverifiedException; fixed poll daemon recovery
- *  1.4.03- Fixed internal mentions of "Ecobee (Connect)"
+ *      1.4.03- Fixed internal mentions of "Ecobee (Connect)"
  *	1.4.04- Handle javax.net.ssl.SSLHandshakeException & java.net.SocketTimeoutException
- *  1.4.05- Improved timeout handling
+ *      1.4.05- Improved timeout handling
  *	1.4.06- Added new Smart Mode helper SmartApp
  *	1.4.07- Trap & avoid errors where no resp.data is returned; fix null+null in SmartRecovery calculations
  *	1.4.08-	Fix the inevitable typo that prevented clean initial install
  *	1.4.09- Trapped another exception (org.apache.http.conn.HttpHostConnectException)
  *	1.4.10- Fixed sendJson LOG error
- *  1.4.10a- Added support for legacy Ecobee Smart thermostats with remote sensors.  Fixed bug with multi-thermostat enumeration of remote sensors.
+ *      1.4.10a- Added support for legacy Ecobee Smart thermostats with remote sensors.  Fixed bug with multi-thermostat enumeration of remote sensors.
+ *      1.4.10b- Resolved potential issue with adding TID info to key name for existing sensors which would force re-configuration
  */  
 import groovy.json.JsonOutput
 
-def getVersionNum() { return "1.4.10a" }
+def getVersionNum() { return "1.4.10b" }
 private def getVersionLabel() { return "Ecobee Suite Manager, version ${getVersionNum()}" }
 private def getHelperSmartApps() {
 	return [ 

--- a/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
+++ b/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
@@ -876,19 +876,19 @@ Map getEcobeeSensors() {
 			if (it.type == "ecobee3_remote_sensor") {
             	LOG("Adding an ecobee3_remote_sensor: ${it}", 4, null, "trace")
 				def value = "${it?.name}"
-				def key = "ecobee_suite-sensor-" + tid + "." + it?.id + "-" + it?.code
+				def key = "ecobee_suite-sensor-" + it?.id + "-" + it?.code
 				sensorMap["${key}"] = value
 			} else if ( (it.type == "thermostat") && (settings.showThermsAsSensor == true) ) {            	
 				LOG("Adding a Thermostat as a Sensor: ${it}", 4, null, "trace")
            	    def value = "${it?.name}"
-				def key = "ecobee_suite-sensor_tstat-" + tid + "." + it?.id + "-" + it?.name
+				def key = "ecobee_suite-sensor_tstat-" + it?.id + "-" + it?.name
        	       	LOG("Adding a Thermostat as a Sensor: ${it}, key: ${key}  value: ${value}", 4, null, "trace")
 				sensorMap["${key}"] = value + " (Thermostat)"
        	   	} else if ( it.type == "control_sensor" && it.capability[0]?.type == "temperature") {
        	   		// We can add this one as it supports temperature
        	      	LOG("Adding a control_sensor: ${it}", 4, null, "trace")
 				def value = "${it?.name}"
-				def key = "ecobee_suite-control_sensor-" + tid + "." + it?.id
+				def key = "ecobee_suite-control_sensor-" + it?.id
 				sensorMap["${key}"] = value
             } else if (it.type == "monitor_sensor" && it.capability[0]?.type == "temperature" && it?.name != "") {
             	LOG("Adding a monitor_sensor: ${it}", 4, null, "trace")
@@ -2302,15 +2302,15 @@ def updateSensorData() {
         	switch (it.type) {
             	case 'ecobee3_remote_sensor':
                 	// Ecobee3 remote temp/occupancy sensor
-                	sensorDNI = "ecobee_suite-sensor-" + tid + "." + it?.id + "-" + it?.code
+                	sensorDNI = "ecobee_suite-sensor-" + it?.id + "-" + it?.code
                     break;
                 case 'control_sensor':
                 	// SmartSI style control sensor (temp or humidity)
-                	sensorDNI = "ecobee_suite-control_sensor-" + tid + "." + it?.id
+                	sensorDNI = "ecobee_suite-control_sensor-" + it?.id
                     break;
                 case 'thermostat':
                 	// The thermostat itself
-                	sensorDNI = "ecobee_suite-sensor_tstat-" + tid + "." + it?.id + "-" + it?.name
+                	sensorDNI = "ecobee_suite-sensor_tstat-" + it?.id + "-" + it?.name
                     break;
                 case 'monitor_sensor':
                 	// Smart style remote sensor (temp or humidity)


### PR DESCRIPTION
Great work on the Ecobee-Suite SmartThings app!  I'd like to offer a couple of enhancements for your consideration.

**Background:**  I have 2 early-model Ecobee Smart thermostats with Remote Sensor Modules measuring several other locations.  I found that the existing code enumerated the thermostats and the remote sensors correctly, but failed to present them on the SmartThings app for two reasons:
1)  The assignment of the sensorMap key value did not account for making the sensor unique to a particular thermostat.  The effect was that only the last-enumerated thermostat would have its sensors available in the sensorMap array.  I fixed this by including the tid of the thermostat, separated with a '.' from the sensor id so that it didn't break downstream parsing based on splitting the string on the '-' character.
2)  The code did not handle the type "monitor_sensor" which is used by the Ecobee Smart RSM sensors.  This was easy to fix by including a new handler patterned on the "ecobee3_remote_sensor".  I also handle the case of the sensor name being blank, which indicates that the sensor is not configured on the thermostat.

If you're happy with the changes, please consider them as a contribution to the main fork.