### PR TITLE
Fix setHold() missing double quote

### DIFF
--- a/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
+++ b/smartapps/sandood/ecobee-suite-manager.src/ecobee-suite-manager.groovy
@@ -5406,7 +5406,7 @@ boolean setHold(child, heating, cooling, deviceId, sendHoldType='indefinite', se
 	} 
 	
 	def jsonRequestBody = '{"selection":{"selectionType":"thermostats","selectionMatch":"' + deviceId + '"},"functions":[{"type":"setHold","params":{"coolHoldTemp":"' + c + '","heatHoldTemp":"' + h + 
-							'","holdType":' + theHoldType + '"}}]}'
+							'","holdType":"' + theHoldType + '"}}]}'
 
 	if (debugLevelFour) LOG("setHold() for thermostat ${child.device.displayName} - about to sendJson with jsonRequestBody (${jsonRequestBody}", 4, child)
 	


### PR DESCRIPTION
Was getting invalid holdType parameter error:
`errorsendJson() - httpPost error: 500, Internal Server Error, [status:[code:11, message:Function error. Invalid holdType parameter value: indefinite". Supported values: dateTime,nextTransition,indefinite,holdHours Function: setHold]] - won't retry`