### PR TITLE
Fix Smart Circulation app, atomicState.minutes -> circMinutes

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -49,7 +49,7 @@
       "location": "https://raw.githubusercontent.com/SANdood/Ecobee-Suite/master/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy",
       "required": true,
       "oauth": false,
-      "version": "1.9.00"
+      "version": "1.9.00a"
     },
     {
       "id": "d14d22cf-bdb4-4d12-8c89-ac849a5e0e53",

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,8 +1,8 @@
 {
   "packageName": "Ecobee Suite",
-  "author": "Barry A. Burke",
+  "author": "[bdruth-fork] Barry A. Burke",
   "minimumHEVersion": "2.3.3",
-  "dateReleased": "2022-12-12",
+  "dateReleased": "2024-11-30",
   "releaseNotes": "This update fixes errors in thermostatOperatingMode and in the Smart Circulation and Smart Mode Helpers",
   "communityLink": "https://community.hubitat.com/t/release-universal-ecobee-suite-version-1-8-01/34839/796",
   "apps": [

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -46,7 +46,7 @@
       "id": "cc05b8d1-01b7-449e-b12b-9f56ccbdf23c",
       "name": "ecobee Suite Smart Circulation",
       "namespace": "sandood",
-      "location": "https://raw.githubusercontent.com/SANdood/Ecobee-Suite/master/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy",
+      "location": "https://raw.githubusercontent.com/bdruth/Ecobee-Suite/refs/heads/master/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy",
       "required": true,
       "oauth": false,
       "version": "1.9.00a"

--- a/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy
+++ b/smartapps/sandood/ecobee-suite-smart-circulation.src/ecobee-suite-smart-circulation.groovy
@@ -805,7 +805,7 @@ void updateMyLabel() {
 	if (settings.tempDisable) {
 		newLabel = myLabel + '<span style="color:red"> (paused)</span>'
 		if (app.label != newLabel) app.updateLabel(newLabel)
-	} else if (atomicState.minutes == 'quiet time') {
+	} else if (atomicState.circMinutes == 'quiet time') {
 		newLabel = myLabel + '<span style="color:green"> (quiet time)</span>'
 		if (app.label != newLabel) app.updateLabel(newLabel)
 	} else if (minutes > -1) { 


### PR DESCRIPTION
[An edit](https://github.com/SANdood/Ecobee-Suite/commit/da14c6d97fded23755e4ce804864502c7c8287c5) made for 1.8.00a (2020) seems to have mistakenly used `atomicState.minutes` instead of `atomicState.circMinutes`, causing a ClassCastException during evaluation if this conditional logic is executed.